### PR TITLE
build(deps): upgrade urijs to v1.19.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "lodash": "~4.17.15",
-    "urijs": "^1.19.1"
+    "urijs": "^1.19.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5654,10 +5654,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-urijs@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.1.tgz#5b0ff530c0cbde8386f6342235ba5ca6e995d25a"
-  integrity sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg==
+urijs@^1.19.2:
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.2.tgz#f9be09f00c4c5134b7cb3cf475c1dd394526265a"
+  integrity sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w==
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
# Upgrade urijs to v1.19.2

## :arrow_up: Upgrade

9ceb96b - build(deps): upgrade urijs to v1.19.2

uses: `yarn upgrade-interactive --latest urijs`
- urijs@1.19.2

## :link: Related

- https://github.com/medialize/URI.js/compare/v1.19.1...v1.19.2

## :house: Internal

- No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>